### PR TITLE
ADD a subcommand to push changes without committing.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup, find_packages
 
-requirements = ['Click>=7.0', 'requests', 'pyyaml']
+requirements = ['Click>=7.0', 'requests', 'pyyaml', 'GitPython']
 
 setup_requirements = []
 test_requirements = []


### PR DESCRIPTION
This depends on AnubisLMS/Anubis#389.

This adds a command `push` that accepts an optional argument `-f`/`--force`
to use the sidecar to push local changes with the bot's credentials. This saves
students from setting up their own credentials to push changes.

Sample usages:
- `anubis push`
- `anubis push -f`
- `anubis push --force`